### PR TITLE
Ignore a directory listing fail if the directory doesn't exist

### DIFF
--- a/package/yast2-gpmc.changes
+++ b/package/yast2-gpmc.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Sep 12 20:26:18 UTC 2019 - dmulder@suse.com
+
+- Ignore directory listing if directory doesn't exist; (bsc#1150614);
+- 1.4.5
+
+-------------------------------------------------------------------
 Thu Aug 22 19:31:25 UTC 2019 - dmulder@suse.com
 
 - SamDB interface now allows gpmc to use krb5 auth; (boo#1146898);

--- a/package/yast2-gpmc.spec
+++ b/package/yast2-gpmc.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-gpmc
-Version:        1.4.4
+Version:        1.4.5
 Release:        0
 Summary:        Group Policy Management Console for YaST
 License:        GPL-3.0-only


### PR DESCRIPTION
gpmc was trying to list the PolicyDefinitions
directory to lookup additional settings. On a new
AD domain, this directory may not exist yet.
Don't crash if it's missing.